### PR TITLE
Bugfix/use correct symbol table php71

### DIFF
--- a/extension/php7/meminfo.c
+++ b/extension/php7/meminfo.c
@@ -54,6 +54,7 @@ PHP_FUNCTION(meminfo_dump)
 
     php_stream *stream;
     HashTable *visited_items;
+    zend_array *p_symbol_table;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zval_stream) == FAILURE) {
         return;
@@ -80,7 +81,7 @@ PHP_FUNCTION(meminfo_dump)
         // Switch the active frame to the current browsed one and rebuild the symbol table
         // to get it right
         EG(current_execute_data) = exec_frame;
-        zend_rebuild_symbol_table();
+        p_symbol_table = zend_rebuild_symbol_table();
 
         // Once we have the symbol table, switch to the prev frame to get the right frame name
         prev_frame = exec_frame->prev_execute_data;
@@ -93,7 +94,7 @@ PHP_FUNCTION(meminfo_dump)
             }
         }
 
-        meminfo_browse_zvals_from_symbol_table(stream, frame_label, &EG(symbol_table), visited_items, &first_element);
+        meminfo_browse_zvals_from_symbol_table(stream, frame_label, p_symbol_table, visited_items, &first_element);
 
         exec_frame = exec_frame->prev_execute_data;
     }

--- a/extension/php7/meminfo.c
+++ b/extension/php7/meminfo.c
@@ -226,6 +226,8 @@ void meminfo_zval_dump(php_stream * stream, char * frame_label, zend_string * sy
 
     if (Z_TYPE_P(zv) == IS_INDIRECT) {
         zv = Z_INDIRECT_P(zv);
+    } else if (Z_ISREF_P(zv)) {
+        ZVAL_DEREF(zv);
     }
 
     php_stream_printf(stream TSRMLS_CC, "    \"%s\" : {\n", zval_id);


### PR DESCRIPTION
I tried using php-meminfo to investigate a problem with classes not being released somewhere but ran into a few snags when running with PHP 7.1 / PHP 7.2 which I hope to address in this PR. I've verified this to work (more accurately) in PHP 7.1 and expect it to run in PHP 7.2.

* When I assigned a variable to a property on 'the current object' (as in, the object whose method I ran meminfo_dump() in) that property would get ignored as it was a seen as a reference. This change dereferences any references. 
* I ended up with the same data over and over again and I wouldn't find variables I'd expect to find in the output of php-meminfo. It appears PHP 7.1+ has changed the way symbol tables are referenced. This change reflects that. 