### PR TITLE
Fix segfault when zend_rebuild_symbol_table returns null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.4 Ygramul (2018-08-13)
+ - [GITHUB-75](https://github.com/BitOne/php-meminfo/issues/75) Now goes through static members of classes as well the usual frame execution browsing.
+
 # 1.0.3 Ygramul (2018-08-13)
  - [GITHUB-76](https://github.com/BitOne/php-meminfo/issues/76) Fixes wrong non matching item reference from children, introduced in v1.0.2
 

--- a/extension/php7/meminfo.c
+++ b/extension/php7/meminfo.c
@@ -101,6 +101,10 @@ void meminfo_browse_exec_frames(php_stream *stream,  HashTable *visited_items, i
         // to get it right
         EG(current_execute_data) = exec_frame;
         p_symbol_table = zend_rebuild_symbol_table();
+        if (p_symbol_table == NULL) {
+            exec_frame = exec_frame->prev_execute_data;
+            continue;
+        }
 
         // Once we have the symbol table, switch to the prev frame to get the right frame name
         prev_frame = exec_frame->prev_execute_data;

--- a/extension/php7/tests/segfault-shutdown.phpt
+++ b/extension/php7/tests/segfault-shutdown.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Check that meminfo_dump during shutdown function doesn't segfault.
+--SKIPIF--
+<?php
+    if (!extension_loaded('json')) die('skip json ext not loaded');
+?>
+--FILE--
+<?php
+register_shutdown_function(function () {
+    $myArray = [
+        "1|\x1f" => "My data"
+    ];
+
+    $dump = fopen('php://memory', 'rw');
+
+    meminfo_dump($dump);
+
+    rewind($dump);
+    $meminfoData = json_decode(stream_get_contents($dump), true);
+    fclose($dump);
+
+    if (is_array($meminfoData)) {
+        echo  "meminfo_dump JSON decode ok\n";
+    } else {
+        echo "meminfo_dump JSON decode fail\n";
+    }
+});
+?>
+--EXPECT--
+meminfo_dump JSON decode ok


### PR DESCRIPTION
If `meminfo_dump` is called inside a shutdown function (`register_shutdown_function`), `zend_rebuild_symbol_table` can return `null`. This causes a segfault.

Shutdown functions are used in a couple of different event-loop implementations.

This fix just skips over browsing the `null` symbol table.