### PR TITLE
Use proper type for out parameter

### DIFF
--- a/extension/php7/meminfo.c
+++ b/extension/php7/meminfo.c
@@ -173,7 +173,7 @@ void meminfo_browse_zvals_from_symbol_table(php_stream *stream, char* frame_labe
     HashPosition pos;
 
     zend_string *key;
-    ulong index;
+    zend_long index;
 
     zend_hash_internal_pointer_reset_ex(p_symbol_table, &pos);
 


### PR DESCRIPTION
The third parameter of `zend_hash_get_current_key_ex()` is declared as
`zend_long` which has not necessarily the same size as `ulong` (for
instance, on 64bit Windows the former has eight bytes, while the latter
has only 4 bytes).  However, for out parameters the sizes should match.