### PR TITLE
GITHUB-108: do not browse non existent symbol tables

### DIFF
--- a/extension/php7/meminfo.c
+++ b/extension/php7/meminfo.c
@@ -81,6 +81,7 @@ void meminfo_browse_exec_frames(php_stream *stream,  HashTable *visited_items, i
 {
     zend_execute_data *exec_frame, *prev_frame;
     zend_array *p_symbol_table;
+    zend_array *rebuilt_symbol_table;
 
     exec_frame = EG(current_execute_data);
 
@@ -93,10 +94,10 @@ void meminfo_browse_exec_frames(php_stream *stream,  HashTable *visited_items, i
 
         // copy variables from ex->func->op_array.vars into the symbol table for the last called *user* function
         // therefore it does necessary returns the symbol table of the current frame 
-        zend_rebuild_symbol_table();
+        rebuilt_symbol_table = zend_rebuild_symbol_table();
 
         p_symbol_table = exec_frame->symbol_table;
-        if (p_symbol_table == NULL) {
+        if (p_symbol_table == NULL || p_symbol_table != rebuilt_symbol_table) {
             exec_frame = exec_frame->prev_execute_data;
             continue;
         }


### PR DESCRIPTION
See https://github.com/BitOne/php-meminfo/issues/108


**Context**

The fix https://github.com/BitOne/php-meminfo/pull/106 fixed an issue with a wrong frame name because the symbol table returned by the function `zend_rebuild_symbol_table` does not necessary return the symbol table of the current `zend_execute_data`.

The fix is correct but, since PHP 7.4, it is also the cause of a segfault.

**Behavior in PHP 7.2/7.3**

The symbol table of the current `zend_execute_data` can be the symbol table of:
- the function `meminfo_dump`
- a function with dynamic variables inside (`$$dynamic_variable = test` for example)
- a function without dynamic variables inside
- global context
- etc

In any case, and even before the rebuild of the symbol table, the symbol table is initialized with an empty `zend_array`.

Therefore, it's possible to browse the symbol table of any frame, even `meminfo_dump`.
It does not make sense to browse this frame as it's not a "user" function though. With the fix in #106., this frame `meminfo_dump` is browsed.

**Behavior in PHP 7.4**

The symbol table is *never* initialized for:
- the function `meminfo_dump` as it's not a user function

Also, the symbol table is not initialized in a function except if:
- there is a dynamic variable
- or a rebuild of the table with `zend_rebuild_symbol_table` is done

Therefore, when `meminfo_dump` frame is browsed, it tries to iterate over an uninitialized array.

**Fix**

A possible solution would be to not browse frame that are not "user" function like it's done here:
https://github.com/php/php-src/blob/php-7.4.13/Zend/zend_execute_API.c#L1476

But I prefered to only browse a frame corresponding to the rebuilt frame:
- more robust to future change In PHP I think
- no need to duplicate the logic from  `zend_rebuild_symbol_table`.