### PR TITLE
Prep beta 2.0 version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,8 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-#        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
-        php-versions: ['8.0']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ $ TEST_PHP_EXECUTABLE=$(which php) $(which php) run-tests.php -d extension=$PWD/
 In this case your tests will run with your local PHP configuration,
 including the loading of the JSON extension.
 
+Please note this is not required when working with PHP 8 as the JSON functions are now
+usually complied in PHP directly.
+
 Credits
 -------
 Thanks to Derick Rethans for his inspirational work on the essential XDebug. See http://www.xdebug.org/

--- a/analyzer/composer.json
+++ b/analyzer/composer.json
@@ -4,9 +4,9 @@
     "type": "project",
     "description": "Tools to analyze meminfo dump files",
     "require": {
-        "symfony/console" : "^5.0",
-        "symfony/filesystem" : "^5.0.0",
-        "symfony/serializer" : "^5.0.0",
+        "symfony/console" : "^3.4 || ^4.4 || ^5.0",
+        "symfony/filesystem" : "^3.4 || ^4.4 || ^5.0",
+        "symfony/serializer" : "^3.4 || ^4.4 || ^5.0",
         "clue/graph": "^0.9.0",
         "graphp/algorithms": "^0.8.1"
     },
@@ -17,6 +17,6 @@
         "psr-4": { "spec\\": "spec/" }
     },
     "require-dev": {
-        "phpspec/phpspec": "^7.0"
+        "phpspec/phpspec": "^4.3 || ^5.1 || ^6.3 || ^7.0"
     }
 }

--- a/extension/php_meminfo.h
+++ b/extension/php_meminfo.h
@@ -5,10 +5,10 @@ extern zend_module_entry meminfo_module_entry;
 #define phpext_meminfo_ptr &meminfo_module_entry
 
 #define MEMINFO_NAME "PHP Meminfo"
-#define MEMINFO_VERSION "1.1.1"
+#define MEMINFO_VERSION "2.0.0-beta1"
 #define MEMINFO_AUTHOR "Benoit Jacquemont"
-#define MEMINFO_COPYRIGHT  "Copyright (c) 2010-2017 by Benoit Jacquemont & contributors"
-#define MEMINFO_COPYRIGHT_SHORT "Copyright (c) 2011-2017"
+#define MEMINFO_COPYRIGHT  "Copyright (c) 2010-2021 by Benoit Jacquemont & contributors"
+#define MEMINFO_COPYRIGHT_SHORT "Copyright (c) 2010-2021"
 
 PHP_FUNCTION(meminfo_dump);
 


### PR DESCRIPTION
The Beta 2.0 version will drop support for PHP 5 and adds support for PHP 8.