### PR TITLE
Add static local variables to the dump

### DIFF
--- a/extension/php_meminfo.h
+++ b/extension/php_meminfo.h
@@ -17,6 +17,7 @@ zend_ulong   meminfo_get_element_size(zval* z);
 // Functions to browse memory parts to record item
 void meminfo_browse_exec_frames(php_stream *stream,  HashTable *visited_items, int *first_element);
 void meminfo_browse_class_static_members(php_stream *stream,  HashTable *visited_items, int *first_element);
+void meminfo_browse_function_static_variables(php_stream *stream, char* class_name, HashTable *function_table, HashTable *visited_items, int *first_element);
 
 void meminfo_zval_dump(php_stream * stream, char * frame_label, zend_string * symbol_name, zval * zv, HashTable *visited_items, int *first_element);
 void meminfo_hash_dump(php_stream *stream, HashTable *ht, zend_bool is_object, HashTable *visited_items, int *first_element);

--- a/extension/tests/dump-class_function_static_local_variables.phpt
+++ b/extension/tests/dump-class_function_static_local_variables.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Check that static variables inside a class member function are accounted for
+--SKIPIF--
+<?php
+    if (!extension_loaded('json')) die('skip json ext not loaded');
+?>
+--FILE--
+<?php
+    $dump = fopen('php://memory', 'rw');
+
+    class MyClass {
+        public function myMethod() {
+            static $staticLocalVar;
+            
+            if (!isset($staticLocalVar)) {
+                $staticLocalVar = 'one time load';
+            }
+            
+            return $staticLocalVar;
+        }
+    }
+    
+    (new MyClass)->myMethod();
+
+    meminfo_dump($dump);
+
+    rewind($dump);
+    $meminfoData = json_decode(stream_get_contents($dump), true);
+    fclose($dump);
+
+    $myArrayDump = [];
+
+    foreach ($meminfoData['items'] as $item) {
+        if (isset($item['symbol_name']) && $item['symbol_name'] == '$staticLocalVar') {
+            echo "Symbol: " . $item['symbol_name'] . "\n";
+            echo "  Frame: " . $item['frame'] . "\n";
+            echo "  Type: " . $item['type'] . "\n";
+            echo "  Is root: " . $item['is_root'] . "\n";
+        }
+    }
+?>
+--EXPECT--
+Symbol: $staticLocalVar
+  Frame: <STATIC_VARIABLE(MyClass::myMethod)>
+  Type: string
+  Is root: 1

--- a/extension/tests/dump-global_function_static_local_variables.phpt
+++ b/extension/tests/dump-global_function_static_local_variables.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Check that static variables inside global functions are accounted for
+--SKIPIF--
+<?php
+    if (!extension_loaded('json')) die('skip json ext not loaded');
+?>
+--FILE--
+<?php
+    $dump = fopen('php://memory', 'rw');
+
+    function myMethod() {
+        static $staticLocalVar;
+        
+        if (!isset($staticLocalVar)) {
+            $staticLocalVar = 'one time load';
+        }
+        
+        return $staticLocalVar;
+    }
+    
+    myMethod();
+
+    meminfo_dump($dump);
+
+    rewind($dump);
+    $meminfoData = json_decode(stream_get_contents($dump), true);
+    fclose($dump);
+
+    $myArrayDump = [];
+
+    foreach ($meminfoData['items'] as $item) {
+        if (isset($item['symbol_name']) && $item['symbol_name'] == '$staticLocalVar') {
+            echo "Symbol: " . $item['symbol_name'] . "\n";
+            echo "  Frame: " . $item['frame'] . "\n";
+            echo "  Type: " . $item['type'] . "\n";
+            echo "  Is root: " . $item['is_root'] . "\n";
+        }
+    }
+?>
+--EXPECT--
+Symbol: $staticLocalVar
+  Frame: <STATIC_VARIABLE(<GLOBAL_FUNCTION>::myMethod)>
+  Type: string
+  Is root: 1


### PR DESCRIPTION
Hello! I have been using php-meminfo to find how my projects tests exhausting memory, and it's been great. Thank you!

However, I found that meminfo misses something: static local variables. Using https://github.com/johannes/php-staticvardumper as a resource (but is 8 years old and worked only on php 5, so I had to do some updates), I augmented php-meminfo to find and add static local variables to the dump. Please see the two test for examples.

I had to make a choice for the frame_label. I chose `<STATIC_VARIABLE(ClassName::MethodName)>`, and in the case that the function wasn't a method, but global, I chose `<GLOBAL_FUNCTION>` for the classname (resulting in `<STATIC_VARIABLE(<GLOBAL_FUNCTION>::MethodName)>`). A little wordy, but I think it conveys the meaning pretty well. These are easily changeable though if you prefer something else :)

Thanks again for the tool and let me know if you'd like anything changed.