### PR TITLE
Fix invalid JSON in type names

### DIFF
--- a/extension/meminfo.c
+++ b/extension/meminfo.c
@@ -331,9 +331,13 @@ void meminfo_zval_dump(php_stream * stream, char * frame_label, zend_string * sy
         *first_element = 0;
     }
 
+    zend_string *zv_type = meminfo_escape_for_json(Z_ISUNDEF_P(zv) ? "null" : zend_get_type_by_const(Z_TYPE_P(zv)));
+
     php_stream_printf(stream, "    \"%s\" : {\n", zval_identifier);
-    php_stream_printf(stream, "        \"type\" : \"%s\",\n", zend_get_type_by_const(Z_TYPE_P(zv)));
+    php_stream_printf(stream, "        \"type\" : \"%s\",\n", ZSTR_VAL(zv_type));
     php_stream_printf(stream, "        \"size\" : \"%ld\",\n", meminfo_get_element_size(zv));
+
+    zend_string_release(zv_type);
 
     if (frame_label) {
         zend_string * escaped_frame_label;


### PR DESCRIPTION
In some cases, type names included binary data.

This PR fixes those type-name problems.

![](https://cdn.screencast.com/uploads/g000302FejgWMlg5TrWjqsrHx9UPF/2022-12-0114-43-32.png?sv=2021-08-06&st=2022-12-01T13%3A57%3A45Z&se=2022-12-02T13%3A57%3A45Z&sr=b&sp=r&sig=i8NAk4VuSH5EE1KwAqKGs8b%2BkKSp%2BXOGhRuOpxdbyog%3D)