### PR TITLE
Add top-ranges command

### DIFF
--- a/analyzer/src/BitOne/PhpMemInfo/Analyzer/TopRanges.php
+++ b/analyzer/src/BitOne/PhpMemInfo/Analyzer/TopRanges.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace BitOne\PhpMemInfo\Analyzer;
+
+use BitOne\PhpMemInfo\Loader;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+class TopRanges
+{
+    public function get(Finder $sortedDumpFiles, bool $showZeroRange = true)
+    {
+        list($min, $max) = $this->getMinMax($sortedDumpFiles);
+
+        $allTypes = [];
+        foreach (array_keys($min) as $type) {
+            $allTypes[$type] = $type;
+        }
+        foreach (array_keys($max) as $type) {
+            $allTypes[$type] = $type;
+        }
+
+        $ranges = [];
+        foreach ($allTypes as $type) {
+            $minVal = $min[$type] ?? 0;
+            $maxVal = $max[$type] ?? 0;
+
+            $rangeVal = $maxVal - $minVal;
+
+            if (($showZeroRange && 0 === $rangeVal) || $rangeVal > 0) {
+                $ranges[$type] = $rangeVal;
+            }
+        }
+
+        arsort($ranges, SORT_NUMERIC);
+
+        return $ranges;
+    }
+
+    private function getTypeCount(array $items)
+    {
+        $typeCount = [];
+
+        foreach ($items as $item) {
+            $type = ('object' === $item['type']) ? $item['class'] : $item['type'];
+
+            if (!array_key_exists($type, $typeCount)) {
+                $typeCount[$type] = 0;
+            }
+
+            ++$typeCount[$type];
+        }
+
+        return $typeCount;
+    }
+
+    private function getMinMax(Finder $sortedDumpFiles)
+    {
+        $loader = new Loader();
+        $min = [];
+        $max = [];
+
+        /** @var SplFileInfo $sortedDumpFile */
+        foreach ($sortedDumpFiles as $sortedDumpFile) {
+            $items = $loader->load($sortedDumpFile->getPathname());
+
+            $typeCount = $this->getTypeCount($items);
+
+            foreach ($typeCount as $type => $count) {
+                if (!array_key_exists($type, $min) || $count < $min[$type]) {
+                    $min[$type] = $count;
+                }
+
+                if (!array_key_exists($type, $max) || $count > $max[$type]) {
+                    $max[$type] = $count;
+                }
+            }
+        }
+
+        return [$min, $max];
+    }
+}

--- a/analyzer/src/BitOne/PhpMemInfo/Console/Application.php
+++ b/analyzer/src/BitOne/PhpMemInfo/Console/Application.php
@@ -6,6 +6,7 @@ use BitOne\PhpMemInfo\Console\Command\QueryCommand;
 use BitOne\PhpMemInfo\Console\Command\ReferencePathCommand;
 use BitOne\PhpMemInfo\Console\Command\SummaryCommand;
 use BitOne\PhpMemInfo\Console\Command\TopChildrenCommand;
+use BitOne\PhpMemInfo\Console\Command\TopRangesCommand;
 use BitOne\PhpMemInfo\Console\Command\TopSizeCommand;
 use Symfony\Component\Console\Application as BaseApplication;
 
@@ -24,5 +25,6 @@ class Application extends BaseApplication
         $this->add(new ReferencePathCommand());
         $this->add(new SummaryCommand());
         $this->add(new TopChildrenCommand());
+        $this->add(new TopRangesCommand());
     }
 }

--- a/analyzer/src/BitOne/PhpMemInfo/Console/Command/TopRangesCommand.php
+++ b/analyzer/src/BitOne/PhpMemInfo/Console/Command/TopRangesCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BitOne\PhpMemInfo\Console\Command;
+
+use BitOne\PhpMemInfo\Analyzer\TopRanges;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+
+class TopRangesCommand extends Command
+{
+    /**
+     * {@inheritedDoc}.
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('top-ranges')
+            ->setDescription('Given a directory of dump files sorted by name, this command displays the top ranges (difference between the largest and smallest values) of the dumped types.')
+            ->addArgument(
+                'dump-dir',
+                InputArgument::REQUIRED,
+                'PHP Meminfo Dump Files directory'
+            )
+            ->addOption('show-zero', null, InputOption::VALUE_NONE, 'Show zero ranges')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dumpDir = $input->getArgument('dump-dir');
+
+        if (!file_exists($dumpDir)) {
+            throw new \InvalidArgumentException(sprintf('Directory %s does not exist.', $dumpDir));
+        }
+
+        $sortedDumpFiles = Finder::create()->files()->in($dumpDir)->name('*.json')->sortByName(true);
+        $output->writeln(sprintf('<info>%d dump files found.</info>', $sortedDumpFiles->count()));
+
+        $topRanges = new TopRanges();
+        $topRangeByType = $topRanges->get($sortedDumpFiles, (bool) $input->getOption('show-zero'));
+
+        $table = new Table($output);
+
+        $table->setHeaders(['Type', 'Range']);
+
+        foreach ($topRangeByType as $type => $range) {
+            $table->addRow([$type, $range]);
+        }
+
+        $table->render();
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
This PR suggests a new command **top-ranges** to follow the evolution of the volume of instances by the range as an indicator.

Given a directory of dump files, generated over process run time:

- dumpDir/001.json
- dumpDir/002.json
- dumpDir/003.json


```bash
bin/analyzer top-ranges dumpDir --show-zero
```

```bash
3 dump files found.
+--------+-------+
| Type   | Range |
+--------+-------+
| Foo    | 4     |
| string | 2     |
| Bar    | 0     |
+--------+-------+
```

It output the [range](https://en.wikipedia.org/wiki/Range_(statistics)) (max instance count - min instance count) of the volume of objects of each type.