### PR TITLE
Generate Phar file for Analyzer tool, for easier distribution.

### DIFF
--- a/analyzer/.gitignore
+++ b/analyzer/.gitignore
@@ -1,2 +1,3 @@
+/.build/
 /vendor/
 /composer.lock

--- a/analyzer/box.json.dist
+++ b/analyzer/box.json.dist
@@ -1,0 +1,14 @@
+{
+  "chmod": "0755",
+  "main": "bin/analyzer",
+  "output": ".build/meminfo.phar",
+  "directories": ["."],
+  "finder": [
+    {
+      "name": "*.php",
+      "exclude": ["test", "tests"],
+      "in": "vendor"
+    }
+  ],
+  "stub": true
+}

--- a/bin/build-phar.sh
+++ b/bin/build-phar.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+cd analyzer
+
+# Prepare buld dir
+rm -rf .build
+mkdir .build
+
+# Install app deps
+rm -rf vendor
+composer install --no-dev
+
+# Install Box
+curl -L -o .build/box.phar https://github.com/box-project/box/releases/download/3.9.0/box.phar
+
+# Compile Phar
+php --define phar.read_only=0 .build/box.phar build
+
+# Create signature
+sha256sum .build/meminfo.phar > .build/meminfo.phar.sha256


### PR DESCRIPTION
Add the ability to build the Analyzer command as a phar file: meminfo.phar

The meminfo.phar file can be built using ./bin/build-phar.sh as part of a release.

The build script will;
 - pre-clean the build dir
 - Install the Vendor dependencies,
 - Install "Box" for phar packaging
 - Create meminfo.phar using Box.
 - Create an sha256 hash for meminfo.phar

Supplying a Phar file makes it a lot easier to use the Analyzer tool, instead of having to download and install the repo, as either a global or isolated dependency.

Box version is locked to be compatible with PHP 7.2 as this was the environment I had available.