### PR TITLE
Fix static members null pointer exception

### DIFF
--- a/extension/meminfo.c
+++ b/extension/meminfo.c
@@ -144,7 +144,7 @@ void meminfo_browse_class_static_members(php_stream *stream,  HashTable *visited
     while ((class_entry = zend_hash_get_current_data_ptr_ex(CG(class_table), &ce_pos)) != NULL) {
 
 #if PHP_VERSION_ID >= 70400
-        if (class_entry->default_static_members_count > 0 && CE_STATIC_MEMBERS(class_entry)) {
+        if (class_entry->default_static_members_count > 0 && ZEND_MAP_PTR(class_entry->static_members_table) && CE_STATIC_MEMBERS(class_entry)) {
 #else
         if (class_entry->static_members_table) {
 #endif


### PR DESCRIPTION
Fixes: #129 

STR:
1) create classes

```php 

if (\PHP_VERSION_ID >= 80000) {
    class TokenPolyfill extends \PhpToken {
    }
    return;
}

class TokenPolyfill {
private static array $identifierTokens;
}
```
2) Create object

```php
$req = new TokenPolyfill(\T_NULLSAFE_OBJECT_OPERATOR, '?->', 10, 10);
\meminfo_dump(\fopen('/tmp/mem_dump.json', 'w'));
```

3) Segmentation fault

```
Program received signal SIGSEGV, Segmentation fault
0x00007ffff2b43fb6 in meminfo_browse_class_static_members (stream=stream@entry=0x7ffff54c2ee0, visited_items=visited_items@entry=0x7fffed5f8cf0, first_element=first_element@entry=0x7fffed5f8ce4)
    at /opt/progs/php-meminfo/extension/meminfo.c:147
147	        if (class_entry->default_static_members_count > 0 && CE_STATIC_MEMBERS(class_entry)) {
(gdb) bt 
#0  0x00007ffff2b43fb6 in meminfo_browse_class_static_members (stream=stream@entry=0x7ffff54c2ee0, visited_items=visited_items@entry=0x7fffed5f8cf0, first_element=first_element@entry=0x7fffed5f8ce4)
    at /opt/progs/php-meminfo/extension/meminfo.c:147
#1  0x00007ffff2b445be in zif_meminfo_dump (execute_data=<optimized out>, return_value=<optimized out>) at /opt/progs/php-meminfo/extension/meminfo.c:80
#2  0x00005555558a5d48 in execute_ex ()
#3  0x000055555582dcbc in zend_call_function ()
#4  0x00005555558d72c9 in ?? ()
#5  0x00005555558d82b2 in ?? ()
#6  0x00005555557d6287 in make_fcontext ()
#7  0x0000000000000000 in ?? ()
```
