### PR TITLE
Ignore __debugInfo magic in obj memory dump

### DIFF
--- a/extension/meminfo.c
+++ b/extension/meminfo.c
@@ -374,7 +374,11 @@ void meminfo_zval_dump(php_stream * stream, char * frame_label, zend_string * sy
         php_stream_printf(stream, "        \"object_handle\" : \"%d\",\n", Z_OBJ_HANDLE_P(zv));
 
 #if PHP_VERSION_ID >= 70400
-        properties = zend_get_properties_for(zv, ZEND_PROP_PURPOSE_DEBUG);
+        zend_object *zobj = Z_OBJ_P(zv);
+        properties = zobj->handlers->get_properties(zobj);
+        if (properties) {
+            GC_TRY_ADDREF(properties);
+        }
 #else
         int is_temp;
         properties = Z_OBJDEBUG_P(zv, is_temp);


### PR DESCRIPTION
Fixes #135 
